### PR TITLE
Disable wayland

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -66,6 +66,7 @@ apps:
     environment:
       TMPDIR: $XDG_RUNTIME_DIR
       XDG_CURRENT_DESKTOP: Unity
+      DISABLE_WAYLAND: 1
     plugs:
       - browser-support
       - camera


### PR DESCRIPTION
Workaround for app not working on wayland session. https://forum.snapcraft.io/t/some-snaps-wont-launch-and-journal-shows-apparmor-denied/9705/5