### PR TITLE
Remove i386 build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,6 @@ confinement: strict
 
 architectures:
   - build-on: amd64
-  - build-on: i386
   
 plugs:
   gnome-3-26-1604:


### PR DESCRIPTION
Upstream no longer publish i386 debs.