### PR TITLE
Migrate to the GNOME 3.28 platform snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -81,16 +81,10 @@ apps:
     plugs:
       - browser-support
       - camera
-      - desktop
-      - desktop-legacy
-      - gsettings
       - home
-      - mount-observe
       - network
       - network-bind
       - opengl
       - pulseaudio
       - screen-inhibit-control
       - unity7
-      - wayland
-      - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,45 +15,13 @@ confinement: strict
 architectures:
   - build-on: amd64
   
-plugs:
-  gnome-3-28-1804:
-    interface: content
-    target: $SNAP/gnome-platform
-    default-provider: gnome-3-28-1804
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/data-dir/themes
-    default-provider: gtk-common-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/data-dir/icons
-    default-provider: gtk-common-themes
-  sound-themes:
-    interface: content
-    target: $SNAP/data-dir/sounds
-    default-provider: gtk-common-themes
-
 parts:
   bsi-trigger: # A non-built part, only used to trigger builds in build.snapcraft.io on upstream changes
     plugin: nil
     source: https://github.com/wireapp/wire-desktop.git
-  desktop-gnome-platform:
-    build-packages:
-    - build-essential
-    - libgtk-3-dev
-    make-parameters:
-    - FLAVOR=gtk3
-    override-build: |
-      snapcraftctl build
-      mkdir -pv $SNAPCRAFT_PART_INSTALL/gnome-platform
-    plugin: make
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: gtk
 
   libappindicator:
     plugin: nil
-    after:
-      - desktop-gnome-platform
     stage-packages:
       - libappindicator3-1
     prime:
@@ -84,7 +52,6 @@ parts:
       rm $SNAPCRAFT_PART_INSTALL/opt/Wire/chrome-sandbox
       sed -i 's|Icon=.*|Icon=/usr/share/icons/hicolor/256x256/apps/wire-desktop\.png|g' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/wire-desktop.desktop
     after:
-      - desktop-gnome-platform
       - libappindicator
     build-packages:
       - dpkg
@@ -92,16 +59,14 @@ parts:
       - sed
       - wget
     stage-packages:
-      - libasound2
-      - libgconf2-4
       - libnspr4
       - libnss3
-      - libpcre3
       - libxss1
 
 apps:
   wire:
-    command: bin/desktop-launch $SNAP/opt/Wire/wire-desktop --no-sandbox
+    extensions: [gnome-3-28]
+    command: opt/Wire/wire-desktop --no-sandbox
     desktop: usr/share/applications/wire-desktop.desktop
     environment:
       # Correct the TMPDIR path for Chromium Framework/Electron to

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,6 +62,14 @@ parts:
       - libnspr4
       - libnss3
       - libxss1
+  cleanup:
+    after: [wire]
+    plugin: nil
+    build-snaps: [ gnome-3-28-1804 ]
+    override-prime: |
+        set -eux
+        cd /snap/gnome-3-28-1804/current
+        find . -type f,l -exec rm -f $SNAPCRAFT_PRIME/{} \;
 
 apps:
   wire:


### PR DESCRIPTION
This pull request migrates to the GNOME 3.28 platform snap and reduces the size of the snap by ~20MB.