### PR TITLE
Add password-manager-service plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ distributions.</p>
     sudo snap install wire
     snap connect wire:camera core:camera
     snap connect wire:mount-observe core:mount-observe
+    snap connect wire:password-manager-service
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,6 +94,7 @@ apps:
       - network
       - network-bind
       - opengl
+      - password-manager-service
       - pulseaudio
       - screen-inhibit-control
       - unity7


### PR DESCRIPTION
## Description
I would like to add the [password-manager-service interface](https://snapcraft.io/docs/password-manager-service-interface) that could allow the Wire Snap to access the desktop environment's keychain

## Issue fixed
See this repo issue thread [here](https://github.com/snapcrafters/wire/issues/15).

Wire's [latest release](https://github.com/wireapp/wire-webapp/releases/tag/2024-04-11-production.0) introduced [an issue](https://github.com/wireapp/wire-desktop/issues/7764) for some Linux users, most relevant the Snap has become unusable.

Wire started to use the system keychain to store users' authentication data, relying on Electron's [safeStorage](https://www.electronjs.org/docs/latest/api/safe-storage), and AppArmor policies now prevent users using the Snap  package to log in.